### PR TITLE
refactor: add a regex to remove the leading v from the tag_name

### DIFF
--- a/__tests__/run.jest.ts
+++ b/__tests__/run.jest.ts
@@ -29,7 +29,7 @@ export const mockLatestVersionResponse = version => {
   octokitMocked.mockImplementation(() => {
     return {
       request: jest.fn().mockImplementation(async () => {
-        return { data: { tag_name: version } };
+        return { data: { tag_name: `v${version}` } };
       }),
     };
   });
@@ -168,10 +168,9 @@ describe('run', () => {
       );
     }
   );
-  test.each(['', undefined])(
-    'failing scenario: missing/invalid remote latest package version=%p',
-    async version => {
-      mockLatestVersionResponse(version);
+  test('failing scenario: missing remote latest package version=%p',
+    async () => {
+      mockLatestVersionResponse(''); // passes an empty string as a version value.
 
       // NOTE: This runs on load, this is how you do that…
       let promise;

--- a/__tests__/version.jest.ts
+++ b/__tests__/version.jest.ts
@@ -32,7 +32,7 @@ const mockLatestVersionResponse = version => {
   octokitMocked.mockImplementation(() => {
     return {
       request: jest.fn().mockImplementation(async () => {
-        return { data: { tag_name: version } };
+        return { data: { tag_name: `v${version}` } };
       }),
     };
   });

--- a/src/version.ts
+++ b/src/version.ts
@@ -76,7 +76,7 @@ export async function getLatestRemoteVersion(
 ): Promise<string> {
   const { data } = await fetchLatestVersion(config);
 
-  const version = data.tag_name;
+  const version = data.tag_name.replace(/^[^0-9]*/, ''); // Removes the v from the tag_name that comes back from the github request.
 
   if (!version) {
     throw new Error(


### PR DESCRIPTION
Introduces removing the initial v from github's tag_name coming back from the response + test updates.