### PR TITLE
bump to v1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
 
       - name: "Compare Version"
         id: compare
-        uses: sharesight/compare-package-json-version-with-latest@v1.2.0
+        uses: sharesight/compare-package-json-version-with-latest@v1.2.1
         with:
           repository: ${{ github.repository }}
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -10588,7 +10588,7 @@ function fetchLatestVersion(config = getConfig()) {
 function getLatestRemoteVersion(config = getConfig()) {
     return __awaiter(this, void 0, void 0, function* () {
         const { data } = yield fetchLatestVersion(config);
-        const version = data.tag_name;
+        const version = data.tag_name.replace(/^[^0-9]*/, ''); // Removes the v from the tag_name that comes back from the github request.
         if (!version) {
             throw new Error(`⚠️ Found no latest version for a repository package on '${config.repository}'.`);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compare-package-json-version-with-latest",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Allows us to compare your local `package.json` version with a Github Package Registry's latest version.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This release includes logic to remove leading v from github's tag_name response prop.